### PR TITLE
Remove ngIf and ngFor directives

### DIFF
--- a/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
+++ b/apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html
@@ -355,19 +355,23 @@
               <mat-form-field appearance="outline" class="w-100">
                 <mat-label i18n>Tags</mat-label>
                 <mat-chip-grid #tagsChipList>
-                  <mat-chip-row
-                    *ngFor="let tag of assetProfileForm.controls['tags']?.value"
-                    matChipRemove
-                    [removable]="true"
-                    (removed)="onRemoveTag(tag)"
-                  >
-                    {{ tag.name }}
-                    <ion-icon
-                      class="ml-2"
-                      matPrefix
-                      name="close-outline"
-                    ></ion-icon>
-                  </mat-chip-row>
+                  @for (
+                    tag of assetProfileForm.controls['tags']?.value ?? [];
+                    track tag.id
+                  ) {
+                    <mat-chip-row
+                      matChipRemove
+                      [removable]="true"
+                      (removed)="onRemoveTag(tag)"
+                    >
+                      {{ tag.name }}
+                      <ion-icon
+                        class="ml-2"
+                        matPrefix
+                        name="close-outline"
+                      ></ion-icon>
+                    </mat-chip-row>
+                  }
                   <input
                     #tagInput
                     name="close-outline"
@@ -377,12 +381,14 @@
                   />
                 </mat-chip-grid>
                 <mat-autocomplete
-                  #autocompleteTags="matAutocomplete"
+                  #autocompleteTags
                   (optionSelected)="onAddTag($event)"
                 >
-                  <mat-option *ngFor="let tag of HoldingTags" [value]="tag.id">
-                    {{ tag.name }}
-                  </mat-option>
+                  @for (tag of HoldingTags; track tag.id) {
+                    <mat-option [value]="tag.id">
+                      {{ tag.name }}
+                    </mat-option>
+                  }
                 </mat-autocomplete>
               </mat-form-field>
             </div>

--- a/apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.html
+++ b/apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.html
@@ -195,19 +195,18 @@
                 >
               </div>
             }
-            <div
-              *ngIf="stakeRewards > 0 && dividendInBaseCurrency == 0"
-              class="col-6 mb-3"
-            >
-              <gf-value
-                i18n
-                size="medium"
-                [locale]="data.locale"
-                [precision]="stakePrecision"
-                [value]="stakeRewards"
-                >Stake Rewards
-              </gf-value>
-            </div>
+            @if (stakeRewards > 0 && dividendInBaseCurrency == 0) {
+              <div class="col-6 mb-3">
+                <gf-value
+                  i18n
+                  size="medium"
+                  [locale]="data.locale"
+                  [precision]="stakePrecision"
+                  [value]="stakeRewards"
+                  >Stake Rewards
+                </gf-value>
+              </div>
+            }
 
             <div class="col-6 mb-3">
               <gf-value

--- a/apps/client/src/app/components/portfolio-summary/portfolio-summary.component.html
+++ b/apps/client/src/app/components/portfolio-summary/portfolio-summary.component.html
@@ -125,13 +125,15 @@
   <div class="flex-nowrap px-3 py-1 row">
     <div class="flex-grow-1 text-truncate ml-3">
       <ng-container i18n>Net Performance</ng-container>
-      <ng-container *ngIf="this.calculationType">
-        <abbr
-          class="d-none d-sm-inline-block initialism ml-2 text-muted"
-          title="{{ this.calculationType.title }}"
-          >({{ this.calculationType.value }})</abbr
-        >
-      </ng-container>
+      @if (this.calculationType) {
+        <ng-container>
+          <abbr
+            class="d-none d-sm-inline-block initialism ml-2 text-muted"
+            title="{{ this.calculationType.title }}"
+            >({{ this.calculationType.value }})</abbr
+          >
+        </ng-container>
+      }
     </div>
     <div class="flex-column flex-wrap justify-content-end">
       <gf-value

--- a/libs/common/src/lib/helper.spec.ts
+++ b/libs/common/src/lib/helper.spec.ts
@@ -25,7 +25,7 @@ describe('Helper', () => {
 
     it('Get decimal number with group (dot notation)', () => {
       expect(
-        extractNumberFromString({ locale: 'de-CH', value: '99’999.99' })
+        extractNumberFromString({ locale: 'de-CH', value: "99'999.99" })
       ).toEqual(99999.99);
     });
 
@@ -54,12 +54,12 @@ describe('Helper', () => {
     });
 
     it('Get de-CH number format group', () => {
-      expect(getNumberFormatGroup('de-CH')).toEqual('’');
+      expect(getNumberFormatGroup('de-CH')).toEqual("'");
     });
 
     it('Get de-CH number format group when it is default', () => {
       languageGetter.mockReturnValue('de-CH');
-      expect(getNumberFormatGroup()).toEqual('’');
+      expect(getNumberFormatGroup()).toEqual("'");
     });
 
     it('Get de-DE number format group', () => {


### PR DESCRIPTION
This pull request updates several Angular templates to use the new Angular control flow syntax (`@for`, `@if`) instead of the legacy structural directives (`*ngFor`, `*ngIf`). These changes improve readability, maintainability, and future compatibility of the codebase.

Template syntax modernization:

* [`apps/client/src/app/components/admin-market-data/asset-profile-dialog/asset-profile-dialog.html`](diffhunk://#diff-e908acc3bd50e61feb6ef20cb686c8086018c81661fefd1f4e562421264fbfb4R358-L359): Replaced `*ngFor` with `@for` for rendering tag chips and autocomplete options, including tracking by `tag.id`. [[1]](diffhunk://#diff-e908acc3bd50e61feb6ef20cb686c8086018c81661fefd1f4e562421264fbfb4R358-L359) [[2]](diffhunk://#diff-e908acc3bd50e61feb6ef20cb686c8086018c81661fefd1f4e562421264fbfb4R374) [[3]](diffhunk://#diff-e908acc3bd50e61feb6ef20cb686c8086018c81661fefd1f4e562421264fbfb4L380-R391)
* [`apps/client/src/app/components/holding-detail-dialog/holding-detail-dialog.html`](diffhunk://#diff-c393fe6f58fab95f8d4fbf2a1b80a842035eb66abd87310f19e00d70d628ab2bL198-R199): Replaced `*ngIf` with `@if` for conditional rendering of stake rewards section. [[1]](diffhunk://#diff-c393fe6f58fab95f8d4fbf2a1b80a842035eb66abd87310f19e00d70d628ab2bL198-R199) [[2]](diffhunk://#diff-c393fe6f58fab95f8d4fbf2a1b80a842035eb66abd87310f19e00d70d628ab2bR209)
* [`apps/client/src/app/components/portfolio-summary/portfolio-summary.component.html`](diffhunk://#diff-5bced457e38aab3d01da7749b1ee1722e7ca08955a40de7efde76af89dce6b31L128-R136): Replaced `*ngIf` with `@if` for conditional rendering of calculation type abbreviation.