### PR TITLE
Performance enhancements

### DIFF
--- a/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/portfolio-calculator.ts
@@ -72,6 +72,9 @@ export abstract class PortfolioCalculator {
 
   private static readonly MAX_INITIALIZATION_ATTEMPTS = 3;
 
+  protected readonly ONE = new Big(1);
+  protected readonly ZERO = new Big(0);
+
   protected readonly logger = new Logger(PortfolioCalculator.name);
 
   protected accountBalanceItems: HistoricalDataItem[];
@@ -219,17 +222,17 @@ export abstract class PortfolioCalculator {
       return {
         activitiesCount: 0,
         createdAt: new Date(),
-        currentValueInBaseCurrency: new Big(0),
+        currentValueInBaseCurrency: this.ZERO,
         errors: [],
         hasErrors: false,
         historicalData: [],
         positions: [],
-        totalCashInBaseCurrency: new Big(0),
-        totalFeesWithCurrencyEffect: new Big(0),
-        totalInterestWithCurrencyEffect: new Big(0),
-        totalInvestment: new Big(0),
-        totalInvestmentWithCurrencyEffect: new Big(0),
-        totalLiabilitiesWithCurrencyEffect: new Big(0)
+        totalCashInBaseCurrency: this.ZERO,
+        totalFeesWithCurrencyEffect: this.ZERO,
+        totalInterestWithCurrencyEffect: this.ZERO,
+        totalInvestment: this.ZERO,
+        totalInvestmentWithCurrencyEffect: this.ZERO,
+        totalLiabilitiesWithCurrencyEffect: this.ZERO
       };
     }
 
@@ -238,9 +241,9 @@ export abstract class PortfolioCalculator {
     const dataGatheringItems: DataGatheringItem[] = [];
     let firstIndex = transactionPoints.length;
     let firstTransactionPoint: TransactionPoint = null;
-    let totalCashInBaseCurrency = new Big(0);
-    let totalInterestWithCurrencyEffect = new Big(0);
-    let totalLiabilitiesWithCurrencyEffect = new Big(0);
+    let totalCashInBaseCurrency = this.ZERO;
+    let totalInterestWithCurrencyEffect = this.ZERO;
+    let totalLiabilitiesWithCurrencyEffect = this.ZERO;
 
     for (const {
       assetSubClass,
@@ -526,56 +529,56 @@ export abstract class PortfolioCalculator {
     }
 
     for (const dateString of chartDates) {
-      let investmentValueWithCurrencyEffect = new Big(0);
-      let totalCashValueWithCurrencyEffect = new Big(0);
-      let totalCurrentValue = new Big(0);
-      let totalCurrentValueWithCurrencyEffect = new Big(0);
-      let totalInvestmentValue = new Big(0);
-      let totalInvestmentValueWithCurrencyEffect = new Big(0);
-      let totalNetPerformanceValue = new Big(0);
-      let totalNetPerformanceValueWithCurrencyEffect = new Big(0);
-      let totalNetWorthValueWithCurrencyEffect = new Big(0);
-      let totalTimeWeightedInvestmentValue = new Big(0);
-      let totalTimeWeightedInvestmentValueWithCurrencyEffect = new Big(0);
+      let investmentValueWithCurrencyEffect = this.ZERO;
+      let totalCashValueWithCurrencyEffect = this.ZERO;
+      let totalCurrentValue = this.ZERO;
+      let totalCurrentValueWithCurrencyEffect = this.ZERO;
+      let totalInvestmentValue = this.ZERO;
+      let totalInvestmentValueWithCurrencyEffect = this.ZERO;
+      let totalNetPerformanceValue = this.ZERO;
+      let totalNetPerformanceValueWithCurrencyEffect = this.ZERO;
+      let totalNetWorthValueWithCurrencyEffect = this.ZERO;
+      let totalTimeWeightedInvestmentValue = this.ZERO;
+      let totalTimeWeightedInvestmentValueWithCurrencyEffect = this.ZERO;
 
       for (const symbol of Object.keys(valuesBySymbol)) {
         const symbolValues = valuesBySymbol[symbol];
 
         const currentValue =
-          symbolValues.currentValues?.[dateString] ?? new Big(0);
+          symbolValues.currentValues?.[dateString] ?? this.ZERO;
         const currentValueWithCurrencyEffect =
           symbolValues.currentValuesWithCurrencyEffect?.[dateString] ??
-          new Big(0);
+          this.ZERO;
         const investmentValueAccumulated =
-          symbolValues.investmentValuesAccumulated?.[dateString] ?? new Big(0);
+          symbolValues.investmentValuesAccumulated?.[dateString] ?? this.ZERO;
         const investmentValueAccumulatedWithCurrencyEffect =
           symbolValues.investmentValuesAccumulatedWithCurrencyEffect?.[
             dateString
-          ] ?? new Big(0);
+          ] ?? this.ZERO;
         const investmentValueWithCurrencyEffectForSymbol =
           symbolValues.investmentValuesWithCurrencyEffect?.[dateString] ??
-          new Big(0);
+          this.ZERO;
         const netPerformanceValue =
-          symbolValues.netPerformanceValues?.[dateString] ?? new Big(0);
+          symbolValues.netPerformanceValues?.[dateString] ?? this.ZERO;
         const netPerformanceValueWithCurrencyEffect =
           symbolValues.netPerformanceValuesWithCurrencyEffect?.[dateString] ??
-          new Big(0);
+          this.ZERO;
         const netWorthValueWithCurrencyEffect =
           symbolValues.netWorthValuesWithCurrencyEffect?.[dateString] ??
-          new Big(0);
+          this.ZERO;
         const timeWeightedInvestmentValue =
-          symbolValues.timeWeightedInvestmentValues?.[dateString] ?? new Big(0);
+          symbolValues.timeWeightedInvestmentValues?.[dateString] ?? this.ZERO;
         const timeWeightedInvestmentValueWithCurrencyEffect =
           symbolValues.timeWeightedInvestmentValuesWithCurrencyEffect?.[
             dateString
-          ] ?? new Big(0);
+          ] ?? this.ZERO;
 
         investmentValueWithCurrencyEffect =
           investmentValueWithCurrencyEffect.add(
             investmentValueWithCurrencyEffectForSymbol
           );
         totalCashValueWithCurrencyEffect = totalCashValueWithCurrencyEffect.add(
-          cashSymbols.has(symbol) ? netWorthValueWithCurrencyEffect : new Big(0)
+          cashSymbols.has(symbol) ? netWorthValueWithCurrencyEffect : this.ZERO
         );
         totalCurrentValue = totalCurrentValue.add(currentValue);
         totalCurrentValueWithCurrencyEffect =
@@ -722,7 +725,7 @@ export abstract class PortfolioCalculator {
         );
         return sum.plus(new Big(price).mul(holdings[endString][holding]));
       }
-    }, new Big(0));
+    }, this.ZERO);
   }
 
   @LogPerformance
@@ -767,7 +770,7 @@ export abstract class PortfolioCalculator {
         investment: transactionPoint.items.reduce(
           (investment, transactionPointSymbol) =>
             investment.plus(transactionPointSymbol.investment),
-          new Big(0)
+          this.ZERO
         )
       };
     });
@@ -786,7 +789,7 @@ export abstract class PortfolioCalculator {
     for (const { date, investmentValueWithCurrencyEffect } of data) {
       const dateGroup =
         groupBy === 'month' ? date.substring(0, 7) : date.substring(0, 4);
-      groupedData[dateGroup] = (groupedData[dateGroup] ?? new Big(0)).plus(
+      groupedData[dateGroup] = (groupedData[dateGroup] ?? this.ZERO).plus(
         investmentValueWithCurrencyEffect
       );
     }
@@ -929,8 +932,8 @@ export abstract class PortfolioCalculator {
     };
   }): HistoricalDataItem[] {
     let previousDateString = '';
-    let timeWeightedPerformancePreviousPeriod = new Big(0);
-    let timeWeightedPerformancePreviousPeriodWithCurrencyEffect = new Big(0);
+    let timeWeightedPerformancePreviousPeriod = this.ZERO;
+    let timeWeightedPerformancePreviousPeriodWithCurrencyEffect = this.ZERO;
     return Object.entries(accumulatedValuesByDate).map(([date, values]) => {
       const {
         investmentValueWithCurrencyEffect,
@@ -1083,8 +1086,8 @@ export abstract class PortfolioCalculator {
 
         if (newQuantity.abs().lt(Number.EPSILON)) {
           // Reset to zero if quantity is (almost) zero to avoid rounding issues
-          investment = new Big(0);
-          newQuantity = new Big(0);
+          investment = this.ZERO;
+          newQuantity = this.ZERO;
         }
 
         currentTransactionPointItem = {
@@ -1096,10 +1099,10 @@ export abstract class PortfolioCalculator {
           symbol,
           activitiesCount: oldAccumulatedSymbol.activitiesCount + 1,
           averagePrice: newQuantity.eq(0)
-            ? new Big(0)
+            ? this.ZERO
             : investment.div(newQuantity).abs(),
           dateOfFirstActivity: oldAccumulatedSymbol.dateOfFirstActivity,
-          dividend: new Big(0),
+          dividend: this.ZERO,
           fee: oldAccumulatedSymbol.fee.plus(fee),
           feeInBaseCurrency:
             oldAccumulatedSymbol.feeInBaseCurrency.plus(feeInBaseCurrency),
@@ -1120,7 +1123,7 @@ export abstract class PortfolioCalculator {
           activitiesCount: 1,
           averagePrice: unitPrice,
           dateOfFirstActivity: date,
-          dividend: new Big(0),
+          dividend: this.ZERO,
           includeInHoldings: INVESTMENT_ACTIVITY_TYPES.includes(type),
           investment: unitPrice.mul(quantity).mul(factor),
           quantity: quantity.mul(factor)
@@ -1146,19 +1149,19 @@ export abstract class PortfolioCalculator {
         return a.symbol?.localeCompare(b.symbol);
       });
 
-      let fees = new Big(0);
+      let fees = this.ZERO;
 
       if (type === 'FEE') {
         fees = fee;
       }
 
-      let interest = new Big(0);
+      let interest = this.ZERO;
 
       if (type === 'INTEREST') {
         interest = quantity.mul(unitPrice);
       }
 
-      let liabilities = new Big(0);
+      let liabilities = this.ZERO;
 
       if (type === 'LIABILITY') {
         liabilities = quantity.mul(unitPrice);
@@ -1376,7 +1379,7 @@ export abstract class PortfolioCalculator {
       const trades: PortfolioOrder[] = preRangeTrades[symbol];
       const startQuantity = trades.reduce((sum, trade) => {
         return sum.plus(trade.quantity.mul(getFactor(trade.type)));
-      }, new Big(0));
+      }, this.ZERO);
       currentHoldings[format(start, DATE_FORMAT)][symbol] = startQuantity;
     }
   }
@@ -1500,7 +1503,7 @@ export abstract class PortfolioCalculator {
       if (transactionDates.some((d) => d === dateString)) {
         const holdings = { ...currentHoldings[previousDateString] };
         investmentByDate[dateString].forEach((trade) => {
-          holdings[trade.assetProfile.symbol] ??= new Big(0);
+          holdings[trade.assetProfile.symbol] ??= this.ZERO;
           holdings[trade.assetProfile.symbol] = holdings[
             trade.assetProfile.symbol
           ].plus(trade.quantity.mul(getFactor(trade.type)));
@@ -1601,7 +1604,6 @@ export abstract class PortfolioCalculator {
     return chartDateMap;
   }
 
-  @LogPerformance
   private handleTimeWeightedPerformance(
     accumulatedValuesByDate: {
       [date: string]: {
@@ -1630,12 +1632,12 @@ export abstract class PortfolioCalculator {
     timeWeightedPerformancePreviousPeriodWithCurrencyEffect: Big;
   } {
     const previousValues = accumulatedValuesByDate[previousDateString] ?? {
-      totalNetPerformanceValue: new Big(0),
-      totalNetPerformanceValueWithCurrencyEffect: new Big(0),
-      totalTimeWeightedInvestmentValue: new Big(0),
-      totalTimeWeightedInvestmentValueWithCurrencyEffect: new Big(0),
-      totalCurrentValue: new Big(0),
-      totalCurrentValueWithCurrencyEffect: new Big(0)
+      totalNetPerformanceValue: this.ZERO,
+      totalNetPerformanceValueWithCurrencyEffect: this.ZERO,
+      totalTimeWeightedInvestmentValue: this.ZERO,
+      totalTimeWeightedInvestmentValueWithCurrencyEffect: this.ZERO,
+      totalCurrentValue: this.ZERO,
+      totalCurrentValueWithCurrencyEffect: this.ZERO
     };
 
     const timeWeightedPerformanceCurrentPeriod = this.divideByOrZero(
@@ -1654,14 +1656,16 @@ export abstract class PortfolioCalculator {
         previousValues.totalCurrentValueWithCurrencyEffect
       );
 
-    const timeWeightedPerformanceInPercentage = new Big(1)
-      .plus(timeWeightedPerformancePreviousPeriod)
-      .mul(new Big(1).plus(timeWeightedPerformanceCurrentPeriod))
+    const timeWeightedPerformanceInPercentage = this.ONE.plus(
+      timeWeightedPerformancePreviousPeriod
+    )
+      .mul(this.ONE.plus(timeWeightedPerformanceCurrentPeriod))
       .minus(1);
-    const timeWeightedPerformanceInPercentageWithCurrencyEffect = new Big(1)
-      .plus(timeWeightedPerformancePreviousPeriodWithCurrencyEffect)
+    const timeWeightedPerformanceInPercentageWithCurrencyEffect = this.ONE.plus(
+      timeWeightedPerformancePreviousPeriodWithCurrencyEffect
+    )
       .mul(
-        new Big(1).plus(timeWeightedPerformanceCurrentPeriodWithCurrencyEffect)
+        this.ONE.plus(timeWeightedPerformanceCurrentPeriodWithCurrencyEffect)
       )
       .minus(1);
 
@@ -1680,7 +1684,7 @@ export abstract class PortfolioCalculator {
 
   private divideByOrZero(fn: (big: Big) => Big, divisor: Big): Big {
     if (divisor.eq(0)) {
-      return new Big(0);
+      return this.ZERO;
     } else {
       return fn(divisor);
     }

--- a/apps/api/src/app/portfolio/calculator/roi/portfolio-calculator-symbolmetrics-helper.ts
+++ b/apps/api/src/app/portfolio/calculator/roi/portfolio-calculator-symbolmetrics-helper.ts
@@ -18,6 +18,7 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
   private chartDates: string[];
   private marketSymbolMap: { [date: string]: { [symbol: string]: Big } };
   private static readonly BUY_SELL_ORDER_TYPES = new Set(['BUY', 'SELL']);
+  private readonly ZERO = new Big(0);
   public constructor(
     ENABLE_LOGGING: boolean,
     marketSymbolMap: { [date: string]: { [symbol: string]: Big } },
@@ -57,11 +58,11 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
           // the value of the end of the day of the start date is taken which
           // differs from the buying price.
           dateRange === 'max'
-            ? new Big(0)
+            ? this.ZERO
             : (symbolMetricsHelper.symbolMetrics
                 .netPerformanceValuesWithCurrencyEffect[rangeStartDateString] ??
-                new Big(0))
-        ) ?? new Big(0);
+                this.ZERO)
+        ) ?? this.ZERO;
 
       const investmentBasis = this.calculateInvestmentBasis(
         symbolMetricsHelper,
@@ -75,7 +76,7 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
         ? symbolMetricsHelper.symbolMetrics.netPerformanceWithCurrencyEffectMap[
             dateRange
           ].div(investmentBasis)
-        : new Big(0);
+        : this.ZERO;
     }
   }
 
@@ -133,7 +134,7 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
     symbolMetricsHelper.exchangeRateAtOrderDate = exchangeRates[order.date];
     const value = order.quantity.gt(0)
       ? order.quantity.mul(order.unitPrice)
-      : new Big(0);
+      : this.ZERO;
 
     this.handleNoneBuyAndSellOrders(order, value, symbolMetricsHelper);
     this.handleStartOrder(
@@ -200,12 +201,12 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
     const valueOfPositionsSold =
       order.type === 'SELL'
         ? order.unitPriceInBaseCurrency.mul(order.quantity)
-        : new Big(0);
+        : this.ZERO;
 
     const valueOfPositionsSoldWithCurrencyEffect =
       order.type === 'SELL'
         ? order.unitPriceInBaseCurrencyWithCurrencyEffect.mul(order.quantity)
-        : new Big(0);
+        : this.ZERO;
 
     symbolMetricsHelper.totalValueOfPositionsSold =
       symbolMetricsHelper.totalValueOfPositionsSold.plus(valueOfPositionsSold);
@@ -233,7 +234,7 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
     ] = (
       symbolMetricsHelper.symbolMetrics.investmentValuesWithCurrencyEffect[
         order.date
-      ] ?? new Big(0)
+      ] ?? this.ZERO
     ).add(transactionInvestmentWithCurrencyEffect);
   }
 
@@ -347,9 +348,9 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
     transactionInvestmentWithCurrencyEffect: Big
   ) {
     if (symbolMetricsHelper.totalUnits.eq(0)) {
-      symbolMetricsHelper.symbolMetrics.totalInvestment = new Big(0);
+      symbolMetricsHelper.symbolMetrics.totalInvestment = this.ZERO;
       symbolMetricsHelper.symbolMetrics.totalInvestmentWithCurrencyEffect =
-        new Big(0);
+        this.ZERO;
       return;
     }
 
@@ -358,7 +359,7 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
         transactionInvestment
       );
     symbolMetricsHelper.symbolMetrics.totalInvestment = newTotalInvestment.lt(0)
-      ? new Big(0)
+      ? this.ZERO
       : newTotalInvestment;
 
     const newTotalInvestmentWithCurrencyEffect =
@@ -367,7 +368,7 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
       );
     symbolMetricsHelper.symbolMetrics.totalInvestmentWithCurrencyEffect =
       newTotalInvestmentWithCurrencyEffect.lt(0)
-        ? new Big(0)
+        ? this.ZERO
         : newTotalInvestmentWithCurrencyEffect;
   }
 
@@ -410,8 +411,8 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
         return this.handleSellTransaction(symbolMetricsHelper, order);
       default:
         return {
-          transactionInvestment: new Big(0),
-          transactionInvestmentWithCurrencyEffect: new Big(0)
+          transactionInvestment: this.ZERO,
+          transactionInvestmentWithCurrencyEffect: this.ZERO
         };
     }
   }
@@ -420,8 +421,8 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
     symbolMetricsHelper: PortfolioCalculatorSymbolMetricsHelperObject,
     order: PortfolioOrderItem
   ) {
-    let transactionInvestment = new Big(0);
-    let transactionInvestmentWithCurrencyEffect = new Big(0);
+    let transactionInvestment = this.ZERO;
+    let transactionInvestmentWithCurrencyEffect = this.ZERO;
     if (symbolMetricsHelper.totalUnits.gt(0)) {
       transactionInvestment = new Big(
         order.quantity.mul(order.unitPriceInBaseCurrency).toNumber()
@@ -530,7 +531,7 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
     symbolMetricsHelper.unitPriceAtEndDate =
       marketSymbolMap[symbolMetricsHelper.endDateString]?.[symbol];
 
-    symbolMetricsHelper.totalUnits = new Big(0);
+    symbolMetricsHelper.totalUnits = this.ZERO;
 
     return symbolMetricsHelper;
   }
@@ -741,9 +742,9 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
   ): PortfolioOrderItem {
     return {
       date: dateString,
-      fee: new Big(0),
-      feeInBaseCurrency: new Big(0),
-      quantity: new Big(0),
+      fee: this.ZERO,
+      feeInBaseCurrency: this.ZERO,
+      quantity: this.ZERO,
       assetProfile: {
         dataSource,
         symbol,
@@ -775,10 +776,10 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
   ) {
     orders.push({
       date: symbolMetricsHelper.startDateString,
-      fee: new Big(0),
-      feeInBaseCurrency: new Big(0),
+      fee: this.ZERO,
+      feeInBaseCurrency: this.ZERO,
       itemType: 'start',
-      quantity: new Big(0),
+      quantity: this.ZERO,
       assetProfile: {
         dataSource,
         symbol,
@@ -790,15 +791,15 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
 
     orders.push({
       date: symbolMetricsHelper.endDateString,
-      fee: new Big(0),
-      feeInBaseCurrency: new Big(0),
+      fee: this.ZERO,
+      feeInBaseCurrency: this.ZERO,
       itemType: 'end',
       assetProfile: {
         dataSource,
         symbol,
         assetSubClass: isCash ? 'CASH' : undefined
       },
-      quantity: new Big(0),
+      quantity: this.ZERO,
       type: 'BUY',
       unitPrice: symbolMetricsHelper.unitPriceAtEndDate
     });
@@ -820,37 +821,37 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
     return {
       currentValues: {},
       currentValuesWithCurrencyEffect: {},
-      feesWithCurrencyEffect: new Big(0),
-      grossPerformance: new Big(0),
-      grossPerformancePercentage: new Big(0),
-      grossPerformancePercentageWithCurrencyEffect: new Big(0),
-      grossPerformanceWithCurrencyEffect: new Big(0),
+      feesWithCurrencyEffect: this.ZERO,
+      grossPerformance: this.ZERO,
+      grossPerformancePercentage: this.ZERO,
+      grossPerformancePercentageWithCurrencyEffect: this.ZERO,
+      grossPerformanceWithCurrencyEffect: this.ZERO,
       hasErrors: false,
-      initialValue: new Big(0),
-      initialValueWithCurrencyEffect: new Big(0),
+      initialValue: this.ZERO,
+      initialValueWithCurrencyEffect: this.ZERO,
       investmentValuesAccumulated: {},
       investmentValuesAccumulatedWithCurrencyEffect: {},
       investmentValuesWithCurrencyEffect: {},
-      netPerformance: new Big(0),
-      netPerformancePercentage: new Big(0),
+      netPerformance: this.ZERO,
+      netPerformancePercentage: this.ZERO,
       netPerformancePercentageWithCurrencyEffectMap: {},
       netPerformanceValues: {},
       netPerformanceValuesWithCurrencyEffect: {},
       netPerformanceWithCurrencyEffectMap: {},
-      timeWeightedInvestment: new Big(0),
+      timeWeightedInvestment: this.ZERO,
       timeWeightedInvestmentValues: {},
       timeWeightedInvestmentValuesWithCurrencyEffect: {},
-      timeWeightedInvestmentWithCurrencyEffect: new Big(0),
-      totalAccountBalanceInBaseCurrency: new Big(0),
-      totalDividend: new Big(0),
-      totalDividendInBaseCurrency: new Big(0),
-      totalInterest: new Big(0),
-      totalInterestInBaseCurrency: new Big(0),
-      totalInvestment: new Big(0),
-      totalInvestmentWithCurrencyEffect: new Big(0),
+      timeWeightedInvestmentWithCurrencyEffect: this.ZERO,
+      totalAccountBalanceInBaseCurrency: this.ZERO,
+      totalDividend: this.ZERO,
+      totalDividendInBaseCurrency: this.ZERO,
+      totalInterest: this.ZERO,
+      totalInterestInBaseCurrency: this.ZERO,
+      totalInvestment: this.ZERO,
+      totalInvestmentWithCurrencyEffect: this.ZERO,
       unitPrices: {},
-      totalLiabilities: new Big(0),
-      totalLiabilitiesInBaseCurrency: new Big(0)
+      totalLiabilities: this.ZERO,
+      totalLiabilitiesInBaseCurrency: this.ZERO
     };
   }
 
@@ -901,6 +902,6 @@ export class RoiPortfolioCalculatorSymbolMetricsHelper {
   }
 
   private getValueOrZero(value: Big | undefined) {
-    return value ?? new Big(0);
+    return value ?? this.ZERO;
   }
 }

--- a/apps/api/src/app/portfolio/calculator/roi/portfolio-calculator.ts
+++ b/apps/api/src/app/portfolio/calculator/roi/portfolio-calculator.ts
@@ -27,17 +27,17 @@ export class RoiPortfolioCalculator extends PortfolioCalculator {
     positions: TimelinePosition[]
   ): PortfolioSnapshot {
     const acc: PerformanceAccumulator = {
-      currentValueInBaseCurrency: new Big(0),
-      grossPerformance: new Big(0),
-      grossPerformanceWithCurrencyEffect: new Big(0),
+      currentValueInBaseCurrency: this.ZERO,
+      grossPerformance: this.ZERO,
+      grossPerformanceWithCurrencyEffect: this.ZERO,
       hasErrors: false,
-      netPerformance: new Big(0),
-      totalCashInBaseCurrency: new Big(0),
-      totalFeesWithCurrencyEffect: new Big(0),
-      totalInvestment: new Big(0),
-      totalInvestmentWithCurrencyEffect: new Big(0),
-      totalTimeWeightedInvestment: new Big(0),
-      totalTimeWeightedInvestmentWithCurrencyEffect: new Big(0)
+      netPerformance: this.ZERO,
+      totalCashInBaseCurrency: this.ZERO,
+      totalFeesWithCurrencyEffect: this.ZERO,
+      totalInvestment: this.ZERO,
+      totalInvestmentWithCurrencyEffect: this.ZERO,
+      totalTimeWeightedInvestment: this.ZERO,
+      totalTimeWeightedInvestmentWithCurrencyEffect: this.ZERO
     };
 
     for (const currentPosition of positions) {
@@ -49,7 +49,7 @@ export class RoiPortfolioCalculator extends PortfolioCalculator {
       hasErrors: acc.hasErrors,
       positions,
       totalFeesWithCurrencyEffect: acc.totalFeesWithCurrencyEffect,
-      totalInterestWithCurrencyEffect: new Big(0),
+      totalInterestWithCurrencyEffect: this.ZERO,
       totalInvestment: acc.totalInvestment,
       totalInvestmentWithCurrencyEffect: acc.totalInvestmentWithCurrencyEffect,
       totalCashInBaseCurrency: acc.totalCashInBaseCurrency,
@@ -59,7 +59,7 @@ export class RoiPortfolioCalculator extends PortfolioCalculator {
       createdAt: new Date(),
       errors: [],
       historicalData: [],
-      totalLiabilitiesWithCurrencyEffect: new Big(0)
+      totalLiabilitiesWithCurrencyEffect: this.ZERO
     };
   }
 


### PR DESCRIPTION
This pull request refactors the handling of zero and one values for Big number calculations throughout the portfolio calculator logic. Instead of repeatedly creating new `Big(0)` and `Big(1)` instances, the code now uses shared, class-level constants (`this.ZERO` and `this.ONE`). This improves code consistency, readability, and may offer minor performance benefits by reducing unnecessary object instantiations.

The most important changes are:

**Refactoring Big number initialization:**
- Introduced `protected readonly ZERO = new Big(0)` and `protected readonly ONE = new Big(1)` as class-level constants in `PortfolioCalculator`, and `private readonly ZERO = new Big(0)` in `RoiPortfolioCalculatorSymbolMetricsHelper`, replacing all instances of `new Big(0)` and `new Big(1)` with these constants throughout the codebase. [[1]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fR75-R77) [[2]](diffhunk://#diff-a73ba98f956fc24d8594eae2401f7946d4d23438bb2d2a3f2a14acd51143338eR21)

**Consistent usage of constants:**
- Updated all method and variable initializations, default values, and conditional assignments in both `PortfolioCalculator` and `RoiPortfolioCalculatorSymbolMetricsHelper` to use `this.ZERO` and `this.ONE` instead of repeatedly creating new Big number instances. [[1]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL222-R235) [[2]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL241-R246) [[3]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL529-R581) [[4]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL725-R728) [[5]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL770-R773) [[6]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL789-R792) [[7]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL932-R936) [[8]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL1086-R1090) [[9]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL1099-R1105) [[10]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL1123-R1126) [[11]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL1149-R1164) [[12]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL1379-R1382) [[13]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL1503-R1506) [[14]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL1633-R1640) [[15]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL1657-R1668) [[16]](diffhunk://#diff-b24132a6f9aeb45d9cbb86cbdf3128d68c0c6805da797bd38e912a20a3d8401fL1683-R1687) [[17]](diffhunk://#diff-a73ba98f956fc24d8594eae2401f7946d4d23438bb2d2a3f2a14acd51143338eL60-R65) [[18]](diffhunk://#diff-a73ba98f956fc24d8594eae2401f7946d4d23438bb2d2a3f2a14acd51143338eL78-R79) [[19]](diffhunk://#diff-a73ba98f956fc24d8594eae2401f7946d4d23438bb2d2a3f2a14acd51143338eL136-R137) [[20]](diffhunk://#diff-a73ba98f956fc24d8594eae2401f7946d4d23438bb2d2a3f2a14acd51143338eL203-R209) [[21]](diffhunk://#diff-a73ba98f956fc24d8594eae2401f7946d4d23438bb2d2a3f2a14acd51143338eL236-R237) [[22]](diffhunk://#diff-a73ba98f956fc24d8594eae2401f7946d4d23438bb2d2a3f2a14acd51143338eL350-R353) [[23]](diffhunk://#diff-a73ba98f956fc24d8594eae2401f7946d4d23438bb2d2a3f2a14acd51143338eL361-R362)

**Minor cleanup:**
- Removed the `@LogPerformance` decorator from the private `handleTimeWeightedPerformance` method, as it is not needed for private/internal methods.

These changes make the codebase easier to maintain and less error-prone by centralizing the creation of common Big number constants.